### PR TITLE
fix(http-headers): overwrite content length header

### DIFF
--- a/src/EmailObfuscatorMiddleware.php
+++ b/src/EmailObfuscatorMiddleware.php
@@ -56,6 +56,7 @@ class EmailObfuscatorMiddleware implements HttpKernelInterface {
             && (!$isAjaxRequest && !$isWebForm)
             && $obfuscateEmails = $this->emailObfuscatorService->obfuscateEmails($content)) {
           $response->setContent($obfuscateEmails);
+          $response->headers->set('Content-Length', strlen($obfuscateEmails), TRUE);
         }
       }
     }


### PR DESCRIPTION
Overwrite content-length header as the response's content most probably has a different size after the obfuscation